### PR TITLE
Use data contracts for all stream/command messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
           name: Docker login
           command: echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USER} --password-stdin
 
+      # Make sure we have latest version of our dependency containers
+      - run:
+          name: Docker pull
+          command: docker pull elementaryrobotics/element-realsense
+
       #
       # Build docker image
       #

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /code/sd-maskrcnn
 RUN pip3 install -r requirements.txt
 RUN python3 setup.py install
 
-COPY --from=element-realsense_realsense:latest \
+COPY --from=elementaryrobotics/element-realsense \
     /code/realsense/contracts.py /code/realsense_contracts.py
 
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /code/sd-maskrcnn
 RUN pip3 install -r requirements.txt
 RUN python3 setup.py install
 
+COPY --from=element-realsense_realsense:latest \
+    /code/realsense/contracts.py /code/realsense_contracts.py
+
 WORKDIR /code
 # The submodule installs an older version that breaks atom-cli
 RUN pip3 install prompt-toolkit --upgrade

--- a/contracts.py
+++ b/contracts.py
@@ -1,0 +1,87 @@
+from lazycontract import LazyContract, LazyProperty, FloatProperty, \
+IntegerProperty, StringProperty, ObjectProperty, ListProperty
+
+class BinaryProperty(LazyProperty):
+    _type = bytes
+    def deserialize(self, obj):
+        return obj if isinstance(obj, self._type) else LazyContractDeserializationError("Must provide bytes object")
+
+class RawContract(LazyProperty):
+    def __init__(self,  *args, **kwargs):
+        super(RawContract, self).__init__(*args, **kwargs)
+        if 'data' not in self._properties:
+            raise LazyContractValidationError("Raw contracts must specify a data field name and type")
+
+    def to_dict(self):
+        raise TypeError("Cannot convert raw contract to dict, use the to_data() function instead")
+
+    def to_data(self):
+        return self.data
+
+class EmptyContract:
+    def __init__(self, data=None):
+        if data != "" and data != b"" and data is not None:
+            raise LazyContractValidationError("Empty contract should contain no data")
+
+    def to_dict(self):
+        raise TypeError("Cannot convert raw contract to dict, use the to_data() function instead")
+
+    def to_data(self):
+        return ""
+
+INSTANCE_SEGMENTATION_ELEMENT_NAME = "instance-segmentation"
+
+# Contracts for commands
+class SegmentCommand:
+    COMMAND_NAME = "segment"
+
+    class Request(EmptyContract):
+        SERIALIZE = False
+
+    class Response(LazyContract):
+        SERIALIZE = True
+
+        rois = ListProperty(ListProperty(IntegerProperty()), required=True)
+        scores = ListProperty(FloatProperty(), required=True)
+        masks = ListProperty(BinaryProperty(), required=True)
+
+class StreamCommand:
+    COMMAND_NAME = "stream"
+
+    # TODO: right now this is a raw string == "true" or "false",
+    # we should change this and anyone who uses it to send a boolean property instead
+    class Request(RawContract):
+        SERIALIZE = False
+        data = StringProperty(required=True)
+
+    class Response(RawContract):
+        SERIALIZE = False
+        data = StringProperty(required=True)
+
+class GetModeCommand:
+    COMMAND_NAME = "get_mode"
+
+    class Request(EmptyContract):
+        SERIALIZE = False
+
+    class Response(RawContract):
+        SERIALIZE = False
+        data = StringProperty(required=True)
+
+class SetModeCommand:
+    COMMAND_NAME = "set_mode"
+
+    class Request(RawContract):
+        SERIALIZE = False
+        data = StringProperty(required=True)
+
+    class Response(RawContract):
+        SERIALIZE = False
+        data = StringProperty(required=True)
+
+# Contracts for publishing to streams
+class ColorStreamContract(LazyContract):
+    STREAM_NAME = "color_mask"
+    SERIALIZE = False
+
+    data = BinaryProperty(required=True)

--- a/contracts.py
+++ b/contracts.py
@@ -1,33 +1,6 @@
-from lazycontract import LazyContract, LazyProperty, FloatProperty, \
+from lazycontract import LazyContract, FloatProperty, \
 IntegerProperty, StringProperty, ObjectProperty, ListProperty
-
-class BinaryProperty(LazyProperty):
-    _type = bytes
-    def deserialize(self, obj):
-        return obj if isinstance(obj, self._type) else LazyContractDeserializationError("Must provide bytes object")
-
-class RawContract(LazyProperty):
-    def __init__(self,  *args, **kwargs):
-        super(RawContract, self).__init__(*args, **kwargs)
-        if 'data' not in self._properties:
-            raise LazyContractValidationError("Raw contracts must specify a data field name and type")
-
-    def to_dict(self):
-        raise TypeError("Cannot convert raw contract to dict, use the to_data() function instead")
-
-    def to_data(self):
-        return self.data
-
-class EmptyContract:
-    def __init__(self, data=None):
-        if data != "" and data != b"" and data is not None:
-            raise LazyContractValidationError("Empty contract should contain no data")
-
-    def to_dict(self):
-        raise TypeError("Cannot convert raw contract to dict, use the to_data() function instead")
-
-    def to_data(self):
-        return ""
+from atom.contracts import BinaryProperty, RawContract, EmptyContract
 
 INSTANCE_SEGMENTATION_ELEMENT_NAME = "instance-segmentation"
 
@@ -45,18 +18,18 @@ class SegmentCommand:
         scores = ListProperty(FloatProperty(), required=True)
         masks = ListProperty(BinaryProperty(), required=True)
 
-class StreamCommand:
+class SetStreamCommand:
     COMMAND_NAME = "stream"
 
-    # TODO: right now this is a raw string == "true" or "false",
+    # TODO: right now this is a binary string == "true" or "false",
     # we should change this and anyone who uses it to send a boolean property instead
     class Request(RawContract):
         SERIALIZE = False
-        data = StringProperty(required=True)
+        data = BinaryProperty(required=True)
 
     class Response(RawContract):
         SERIALIZE = False
-        data = StringProperty(required=True)
+        data = BinaryProperty(required=True)
 
 class GetModeCommand:
     COMMAND_NAME = "get_mode"
@@ -73,14 +46,14 @@ class SetModeCommand:
 
     class Request(RawContract):
         SERIALIZE = False
-        data = StringProperty(required=True)
+        data = BinaryProperty(required=True)
 
     class Response(RawContract):
         SERIALIZE = False
-        data = StringProperty(required=True)
+        data = BinaryProperty(required=True)
 
 # Contracts for publishing to streams
-class ColorStreamContract(LazyContract):
+class ColorMaskStreamContract(LazyContract):
     STREAM_NAME = "color_mask"
     SERIALIZE = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib==2.2.0
+setuptools==41.0.0

--- a/run.py
+++ b/run.py
@@ -151,7 +151,7 @@ class SDMaskRCNNEvaluator:
         else:
             return Response(f"Expected bool, got {type(data)}.")
         return Response(
-            SetStreamCommand.Response(f"Streaming set to {self.stream_enabled}"),
+            SetStreamCommand.Response(f"Streaming set to {self.stream_enabled}").to_data(),
             serialize=SetStreamCommand.Response.SERIALIZE
         )
 
@@ -271,7 +271,7 @@ class SDMaskRCNNEvaluator:
                 _, color_serialized = cv2.imencode(".tif", masked_img)
                 self.element.entry_write(
                     ColorMaskStreamContract.STREAM_NAME,
-                    ColorMaskStreamContract(data=color_serialized.tobytes()),
+                    ColorMaskStreamContract(data=color_serialized.tobytes()).to_dict(),
                     maxlen=30,
                     serialize=ColorMaskStreamContract.SERIALIZE
                 )


### PR DESCRIPTION
Explicitly declare our message schema definitions for our streams/commands, and validate them.
The actual API and logic is unchanged.

This PR also switches us to use the contracts definitions I've added to the realsense repo.

